### PR TITLE
Estate fishing

### DIFF
--- a/TTMouseclickSimulator/SampleProjects/Automatic Fishing - Estate.xml
+++ b/TTMouseclickSimulator/SampleProjects/Automatic Fishing - Estate.xml
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<SimulatorProject xmlns="https://github.com/TTExtensions/MouseClickSimulator">
+  <Title>Automatic Fishing in Toon Estate</Title>
+  <Description>
+The Toon will automatically fish in your estate.
+Before you click on Start, make sure that
+• your fish bucket is empty,
+• you have enough JellyBeans for 20 casts,
+• your toon is standing on the board nearest to the bucket.
+  </Description>
+
+  <MainAction>
+      
+    <Compound type="Sequential">
+        
+      <!-- Use the automatic fishing action for estate 19 times,
+           plus the straight fishing action.
+      -->
+      <Loop count="19"> 
+        <!-- Note: For Halloween, the bubbleColorRgb value is "10, 76, 76"
+              and toleranceRgb is "8, 8, 8".  -->
+        <AutomaticFishing scan1="248, 239" scan2="1492, 660" bubbleColorRgb="49, 128, 120"
+                          toleranceRgb="5, 10, 8" />
+      </Loop> 
+      <!--
+      The last cast must always be straight; otherwise the toon will rotate in
+      the cast direction and the Simulator would be unable to correctly move the Toon
+      to the fisherman. 
+      -->
+     <StraightFishing />
+          
+      <QuitFishing />
+
+      <Pause duration="2200" />
+        
+      <!-- Now go to the fisherman and sell the fish. -->
+      <Compound type="Sequential" minimumPause="50" maximumPause="300" loop="false">
+	    <PressKey key="Down" duration="300" />
+		<PressKey key="Up" duration="1000" />
+		<Pause duration="2200" />
+		<QuitFishing />
+		<Pause duration="2200" />
+		
+        <PressKey key="Left" duration="1200" />
+        <PressKey key="Up" duration="1800" />
+        <Pause duration="1500" />
+          
+        <SellFish />
+          
+        <Pause duration="2000" />
+        <PressKey key="Down" duration="2500" />
+        <Pause duration="2000" />
+      </Compound>
+        
+    </Compound>
+      
+  </MainAction>
+
+</SimulatorProject>


### PR DESCRIPTION
Added estate fishing support (probably not perfect) with a sanity check to ensure that toon does not wander if the "catch" dialog box fails to appear and the cast button is greyed out.